### PR TITLE
docs(adguardhome): add AdGuard Home installation guide for UGOS

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -50,7 +50,8 @@ export default {
                 { text: 'Nextcloud-AIO', link: '/ugos/install/nextcloud-aio' },
                 { text: 'Ngnix Proxy Manager', link: '/ugos/install/npm' },
                 { text: 'OpenWebUI', link: '/ugos/install/open-webui' },
-                { text: 'Tailscale', link: '/ugos/install/tailscale' }
+                { text: 'Tailscale', link: '/ugos/install/tailscale' },
+                 { text: 'AdGuard Home', link: '/ugos/install/adguardhome'} 
               ]
             }
             // Add more sidebar items

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -51,7 +51,7 @@ export default {
                 { text: 'Ngnix Proxy Manager', link: '/ugos/install/npm' },
                 { text: 'OpenWebUI', link: '/ugos/install/open-webui' },
                 { text: 'Tailscale', link: '/ugos/install/tailscale' },
-                 { text: 'AdGuard Home', link: '/ugos/install/adguardhome'} 
+                { text: 'AdGuard Home', link: '/ugos/install/adguardhome'} 
               ]
             }
             // Add more sidebar items

--- a/docs/ugos/install/adguardhome/docker-compose.yml
+++ b/docs/ugos/install/adguardhome/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+    adguardhome:
+        image: adguard/adguardhome
+        container_name: adguardhome
+        restart: unless-stopped
+        volumes:
+            - /volume2/docker/adguardhome/work:/opt/adguardhome/work
+            - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
+        network_mode: host
+        # -->
+        # Port mappings are not required when using network_mode: host
+        # ports:
+        #     - 53:53/tcp # DNS
+        #     - 53:53/udp # DNS
+        #     - 67:67/udp # DHCP
+        #     - 68:68/udp # DHCP
+        #     - 80:80/tcp # Admin-Panel
+        #     - 443:443/tcp # Admin-Panel
+        #     - 443:443/udp # DNS over HTTPS
+        #     - 3000:3000/tcp # Admin-Panel
+        #     - 853:853/tcp # DNS over TLS
+        #     - 853:853/udp # DNS over QUIC
+        #     - 5443:5443/tcp # DNSCrypt
+        #     - 5443:5443/udp # DNSCrypt
+        #     - 6060:6060/tcp # Debugging
+        # <--

--- a/docs/ugos/install/adguardhome/docker-compose.yml
+++ b/docs/ugos/install/adguardhome/docker-compose.yml
@@ -7,20 +7,20 @@ services:
             - /volume2/docker/adguardhome/work:/opt/adguardhome/work
             - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
         network_mode: host
-        # -->
-        # Port mappings are not required when using network_mode: host
+        # The following port mappings are commented out because they are not required when using network_mode: host.
+        # With host networking, the container uses the host's network stack directly and can bind to the necessary ports without explicit mappings.
+        # However, these lines are included as a reference for which ports AdGuard Home typically uses, in case you ever switch to bridge mode or need to troubleshoot:
         # ports:
-        #     - 53:53/tcp # DNS
-        #     - 53:53/udp # DNS
-        #     - 67:67/udp # DHCP
-        #     - 68:68/udp # DHCP
-        #     - 80:80/tcp # Admin-Panel
-        #     - 443:443/tcp # Admin-Panel
+        #     - 53:53/tcp   # DNS
+        #     - 53:53/udp   # DNS
+        #     - 67:67/udp   # DHCP
+        #     - 68:68/udp   # DHCP
+        #     - 80:80/tcp   # Admin Panel
+        #     - 443:443/tcp # Admin Panel
         #     - 443:443/udp # DNS over HTTPS
-        #     - 3000:3000/tcp # Admin-Panel
+        #     - 3000:3000/tcp # Admin Panel
         #     - 853:853/tcp # DNS over TLS
         #     - 853:853/udp # DNS over QUIC
         #     - 5443:5443/tcp # DNSCrypt
         #     - 5443:5443/udp # DNSCrypt
         #     - 6060:6060/tcp # Debugging
-        # <--

--- a/docs/ugos/install/adguardhome/docker-compose.yml
+++ b/docs/ugos/install/adguardhome/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     adguardhome:
-        image: adguard/adguardhome
+        image: adguard/adguardhome:latest
         container_name: adguardhome
         restart: unless-stopped
         volumes:

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -102,8 +102,9 @@ sudo lsof -i :53
 ```
 
 If the command returns no output, port 53 is no longer in use. After that, you should restart your AdGuard Home container.
-
-### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to take over its functionality.
+::: warning
+ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to take over its functionality.
+:::
 
 ## ⚙️ Initial Configuration of AdGuard Home
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -1,6 +1,6 @@
 # How to install AdGuard Home on Docker
 
-> [!TIP] PREREQUISITE  
+> [!NOTE]   
 >AdGuard Home needs to bind to port 53 (DNS). On UGOS, this port is often already used by `dnsmasq` or other services.  
 >Before installing, ensure that no other service is using port 53, or be prepared to disable/conflict-resolving as described below.
 
@@ -73,9 +73,10 @@ services:
 
 Once the deployment is complete, you can access the AdGuard Home web interface by visiting `http://your-nas-name.local:3000` in your browser.
 
-## 🛑 Preventing Port Conflicts with `dnsmasq`
-
-By default, UGOS uses `dnsmasq` to handle DNS requests, which binds to port `53` on `localhost`. This will conflict with AdGuard Home, which also needs to bind to port `53`.
+> [!WARNING]
+> Preventing Port Conflicts with `dnsmasq`:
+>
+>By default, UGOS uses `dnsmasq` to handle DNS requests, which binds to port `53` on `localhost`. This will conflict with AdGuard >Home, which also needs to bind to port `53`.
 
 To resolve this, you need to stop and disable `dnsmasq`:
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -23,14 +23,31 @@ In the wizard, you'll need to provide a Docker Compose configuration file. Below
 
 ```yml
 services:
-  adguardhome:
-    container_name: adguardhome
-    image: adguard/adguardhome:latest
-    restart: unless-stopped
-    network_mode: host
-    volumes:
-      - /volume2/docker/adguardhome/work:/opt/adguardhome/work
-      - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
+    adguardhome:
+        image: adguard/adguardhome:latest
+        container_name: adguardhome
+        restart: unless-stopped
+        volumes:
+            - /volume2/docker/adguardhome/work:/opt/adguardhome/work
+            - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
+        network_mode: host
+        # -->
+        # Port mappings are not required when using network_mode: host
+        # ports:
+        #     - 53:53/tcp # DNS
+        #     - 53:53/udp # DNS
+        #     - 67:67/udp # DHCP
+        #     - 68:68/udp # DHCP
+        #     - 80:80/tcp # Admin-Panel
+        #     - 443:443/tcp # Admin-Panel
+        #     - 443:443/udp # DNS over HTTPS
+        #     - 3000:3000/tcp # Admin-Panel
+        #     - 853:853/tcp # DNS over TLS
+        #     - 853:853/udp # DNS over QUIC
+        #     - 5443:5443/tcp # DNSCrypt
+        #     - 5443:5443/udp # DNSCrypt
+        #     - 6060:6060/tcp # Debugging
+        # <--
 ```
 
 ::: details

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -1,7 +1,6 @@
 # How to install AdGuard Home on Docker
 
-::: tip prerequisite
-**Prerequisite:**  
+::: tip PREREQUISITE  
 AdGuard Home needs to bind to port 53 (DNS). On UGOS, this port is often already used by `dnsmasq` or other services.  
 Before installing, ensure that no other service is using port 53, or be prepared to disable/conflict-resolving as described below.
 :::

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -43,3 +43,27 @@ In the wizard, you'll need to provide a Docker Compose configuration file. Below
 ### 3. Deploy the Project
 
 Once the deployment is complete, you can access the AdGuard Home web interface by visiting `http://your-nas-name.local:3000` in your browser.
+
+## 🛑 Preventing Port Conflicts with `dnsmasq`
+
+By default, UGOS uses `dnsmasq` to handle DNS requests, which binds to port `53` on `localhost`. This will conflict with AdGuard Home, which also needs to bind to port `53`.
+
+To resolve this, you need to stop and disable `dnsmasq`:
+
+### Steps to disable `dnsmasq` on UGOS
+
+```bash
+sudo systemctl stop dnsmasq
+sudo systemctl disable dnsmasq
+
+```
+
+Verify that port 53 is now free
+
+```bash
+sudo lsof -i :53
+
+```
+If the command returns no output, port 53 is no longer in use.
+
+

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -1,0 +1,45 @@
+# How to install AdGuard Home on Docker
+
+AdGuard Home is a network-wide DNS server and blocker that filters ads, trackers, and malicious domains at the DNS level — before they even reach your devices. It acts as a local DNS resolver, allowing you to:
+
+  • Block ads and trackers on all devices (even smart TVs and game consoles)
+  • Monitor and control internet traffic on your network
+  • Set parental controls and filtering rules
+  • Protect your privacy by avoiding third-party DNS providers
+
+Unlike browser-based ad blockers, AdGuard Home works for all devices on your network — with no need to install anything on each one.
+
+## Deploy Container Using Docker Compose
+
+To quickly deploy Home Assistant on UGREEN NAS, it is recommended to use Docker Compose for project management. This method is suitable when you need to create and manage multiple containers, making containerized management convenient.
+
+### 1. Access the Docker Project Interface
+
+In the UGOS Pro system of UGREEN NAS, open the "Docker" app, click "Project > Create" to start the project creation wizard.
+
+### 2. Configure the Docker Compose File
+
+In the wizard, you'll need to provide a Docker Compose configuration file. Below is the example configuration file for AdGuard Home:
+
+	services:
+	  adguardhome:
+		container_name: adguardhome
+		image: adguard/adguardhome:latest
+		restart: unless-stopped
+		network_mode: host
+		volumes:
+		  - /volume2/docker/adguardhome/work:/opt/adguardhome/work
+		  - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
+
+::: details
+
+  - The volumes directive enables persistent storage for AdGuard Home. The local directories `/volume2/docker/adguardhome/work` and `/volume2/docker/adguardhome/conf` on the NAS are mapped to `/opt/adguardhome/work` and `/opt/adguardhome/conf` inside the container. This ensures that all configuration files, logs, and runtime data are stored on the NAS and survive container restarts or updates.
+  - The container_name is set to adguardhome, making it easier to manage the container directly using Docker CLI commands like docker restart adguardhome.
+  - The image directive specifies the AdGuard Home Docker image. Using the latest tag ensures that the container always pulls the most recent stable version when recreated.
+  - The restart policy is set to unless-stopped, which means the container will automatically restart after a crash or reboot, unless you explicitly stop it.
+  - The network_mode is set to host, allowing AdGuard Home to bind directly to ports on the NAS’s network interface. This is required for it to listen on DNS port 53 and handle requests from all devices in your network without complex port forwarding.
+:::
+
+### 3. Deploy the Project
+
+Once the deployment is complete, you can access the AdGuard Home web interface by visiting `http://your-nas-name.local:3000` in your browser.

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -64,9 +64,23 @@ Verify that port 53 is now free
 sudo lsof -i :53
 
 ```
-If the command returns no output, port 53 is no longer in use.
-
+If the command returns no output, port 53 is no longer in use. After that you should restart your Adguard Home container.
 
 ### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to replace its functionality.
 
+# ⚙️ Initial Configuration of AdGuard Home
+
+After the container starts successfully, open the web interface again by visiting  `http://your-nas-name.local:3000` in your browser.
+
+You will be guided through a short setup wizard. In the wizard:
+
+- Set a username and password for the admin interface.
+- Configure which upstream DNS servers to use (e.g., 1.1.1.1 or 8.8.8.8).
+- Define the listening interfaces (usually 0.0.0.0 to listen on all).
+- Optionally enable DHCP services, if AdGuard Home should manage IPs on your network.
+- Review and apply your settings.
+
+Once complete, the dashboard will show DNS statistics and allow further customization like blacklists, rewrites, client rules, and logging.
+
+Make sure to set your router or clients to use your NAS IP as their DNS server so AdGuard Home becomes active in your network.
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -54,24 +54,30 @@ To resolve this, you need to stop and disable `dnsmasq`:
 
 ### Steps to disable `dnsmasq` on UGOS
 
+1. Open a terminal on your computer and connect to your NAS via SSH:
+
+```bash
+ssh youruser@yourNASiP
+```
+
+2. Disable dnsmasq:
+
 ```bash
 sudo systemctl stop dnsmasq
 sudo systemctl disable dnsmasq
-
 ```
 
-Verify that port 53 is now free
+3. Check if port 53 is now free:
 
 ```bash
 sudo lsof -i :53
-
 ```
 
-If the command returns no output, port 53 is no longer in use. After that you should restart your AdGuard Home container.
+If the command returns no output, port 53 is no longer in use. After that, you should restart your AdGuard Home container.
 
-### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to replace its functionality.
+### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to take over its functionality.
 
-# ⚙️ Initial Configuration of AdGuard Home
+## ⚙️ Initial Configuration of AdGuard Home
 
 After the container starts successfully, open the web interface again by visiting  `http://your-nas-name.local:3000` in your browser.
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -118,8 +118,6 @@ You will be guided through a short setup wizard. In the wizard:
 - Optionally enable DHCP services, if AdGuard Home should manage IPs on your network.
 - Review and apply your settings.
 
-Once complete, the dashboard will show DNS statistics and allow further customization like blacklists, rewrites, client rules, and logging.
-
 Make sure to set your router or clients to use your NAS IP as their DNS server so AdGuard Home becomes active in your network.
 
 After the container starts successfully, open the web interface again by visiting  `http://your-nas-name.local:3000` in your browser.
@@ -132,7 +130,24 @@ You will be guided through a short setup wizard. In the wizard:
 - Optionally enable DHCP services, if AdGuard Home should manage IPs on your network.
 - Review and apply your settings.
 
-Once complete, the dashboard will show DNS statistics and allow further customization like blacklists, rewrites, client rules, and logging.
+## 🚀 Next Steps & Advanced Configuration
+
+Now that AdGuard Home is up and running, consider these next steps to enhance your setup:
+
+- **Customize Filtering:**  
+  Add custom blocklists, allowlists, or create client-specific rules for granular control.
+
+- **Enable DNS-over-HTTPS/TLS/QUIC:**  
+  Increase privacy by enabling encrypted DNS protocols in *Settings > DNS Settings*.
+
+- **Backup Configuration:**  
+  Periodically export your AdGuard Home configuration for disaster recovery.
+
+
 
 Make sure to set your router or clients to use your NAS IP as their DNS server so AdGuard Home becomes active in your network.
+
+
+For more advanced topics and troubleshooting, visit the [official AdGuard Home documentation](https://github.com/AdguardTeam/AdGuardHome/wiki).
+
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -63,6 +63,8 @@ Verify that port 53 is now free
 ```bash
 sudo lsof -i :53
 
+```
+
 If the command returns no output, port 53 is no longer in use. After that you should restart your AdGuard Home container.
 
 ### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to replace its functionality.

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -11,7 +11,7 @@ Unlike browser-based ad blockers, AdGuard Home works for all devices on your net
 
 ## Deploy Container Using Docker Compose
 
-To quickly deploy Home Assistant on UGREEN NAS, it is recommended to use Docker Compose for project management. This method is suitable when you need to create and manage multiple containers, making containerized management convenient.
+To quickly deploy AdGuard Home on UGREEN NAS, it is recommended to use Docker Compose for project management. This method is suitable when you need to create and manage multiple containers, making containerized management convenient.
 
 ### 1. Access the Docker Project Interface
 
@@ -63,8 +63,7 @@ Verify that port 53 is now free
 ```bash
 sudo lsof -i :53
 
-```
-If the command returns no output, port 53 is no longer in use. After that you should restart your Adguard Home container.
+If the command returns no output, port 53 is no longer in use. After that you should restart your AdGuard Home container.
 
 ### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to replace its functionality.
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -2,10 +2,10 @@
 
 AdGuard Home is a network-wide DNS server and blocker that filters ads, trackers, and malicious domains at the DNS level — before they even reach your devices. It acts as a local DNS resolver, allowing you to:
 
-  • Block ads and trackers on all devices (even smart TVs and game consoles)
-  • Monitor and control internet traffic on your network
-  • Set parental controls and filtering rules
-  • Protect your privacy by avoiding third-party DNS providers
+  - Block ads and trackers on all devices (even smart TVs and game consoles)
+  - Monitor and control internet traffic on your network
+  - Set parental controls and filtering rules
+  - Protect your privacy by avoiding third-party DNS providers
 
 Unlike browser-based ad blockers, AdGuard Home works for all devices on your network — with no need to install anything on each one.
 
@@ -65,5 +65,8 @@ sudo lsof -i :53
 
 ```
 If the command returns no output, port 53 is no longer in use.
+
+
+### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to replace its functionality.
 
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -76,7 +76,7 @@ Once the deployment is complete, you can access the AdGuard Home web interface b
 > [!CAUTION]
 > Preventing Port Conflicts with `dnsmasq`:
 >
->By default, UGOS uses `dnsmasq` to handle DNS requests, which binds to port `53` on `localhost`. This will conflict with AdGuard >Home, which also needs to bind to port `53`.
+>By default, UGOS uses `dnsmasq` to handle DNS requests, which binds to port `53` on `localhost`. This will conflict with AdGuard Home, which also needs to bind to port `53`.
 
 To resolve this, you need to stop and disable `dnsmasq`:
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -1,5 +1,11 @@
 # How to install AdGuard Home on Docker
 
+::: tip prerequisite
+**Prerequisite:**  
+AdGuard Home needs to bind to port 53 (DNS). On UGOS, this port is often already used by `dnsmasq` or other services.  
+Before installing, ensure that no other service is using port 53, or be prepared to disable/conflict-resolving as described below.
+:::
+
 AdGuard Home is a network-wide DNS server and blocker that filters ads, trackers, and malicious domains at the DNS level — before they even reach your devices. It acts as a local DNS resolver, allowing you to:
 
   - Block ads and trackers on all devices (even smart TVs and game consoles)
@@ -8,6 +14,10 @@ AdGuard Home is a network-wide DNS server and blocker that filters ads, trackers
   - Protect your privacy by avoiding third-party DNS providers
 
 Unlike browser-based ad blockers, AdGuard Home works for all devices on your network — with no need to install anything on each one.
+
+::: warning  
+This guide was last tested for AdGuard Home v0.107.63
+:::  
 
 ## Deploy Container Using Docker Compose
 
@@ -31,23 +41,23 @@ services:
             - /volume2/docker/adguardhome/work:/opt/adguardhome/work
             - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
         network_mode: host
-        # -->
-        # Port mappings are not required when using network_mode: host
+        # The following port mappings are commented out because they are not required when using network_mode: host.
+        # With host networking, the container uses the host's network stack directly and can bind to the necessary ports without explicit mappings.
+        # However, these lines are included as a reference for which ports AdGuard Home typically uses, in case you ever switch to bridge mode or need to troubleshoot:
         # ports:
-        #     - 53:53/tcp # DNS
-        #     - 53:53/udp # DNS
-        #     - 67:67/udp # DHCP
-        #     - 68:68/udp # DHCP
-        #     - 80:80/tcp # Admin-Panel
-        #     - 443:443/tcp # Admin-Panel
+        #     - 53:53/tcp   # DNS
+        #     - 53:53/udp   # DNS
+        #     - 67:67/udp   # DHCP
+        #     - 68:68/udp   # DHCP
+        #     - 80:80/tcp   # Admin Panel
+        #     - 443:443/tcp # Admin Panel
         #     - 443:443/udp # DNS over HTTPS
-        #     - 3000:3000/tcp # Admin-Panel
+        #     - 3000:3000/tcp # Admin Panel
         #     - 853:853/tcp # DNS over TLS
         #     - 853:853/udp # DNS over QUIC
         #     - 5443:5443/tcp # DNSCrypt
         #     - 5443:5443/udp # DNSCrypt
         #     - 6060:6060/tcp # Debugging
-        # <--
 ```
 
 ::: details
@@ -57,6 +67,7 @@ services:
   - The image directive specifies the AdGuard Home Docker image. Using the latest tag ensures that the container always pulls the most recent stable version when recreated.
   - The restart policy is set to unless-stopped, which means the container will automatically restart after a crash or reboot, unless you explicitly stop it.
   - The network_mode is set to host, allowing AdGuard Home to bind directly to ports on the NAS’s network interface. This is required for it to listen on DNS port 53 and handle requests from all devices in your network without complex port forwarding.
+  - **Note:** The commented-out `ports:` section in the Compose file above is not needed with `network_mode: host`, but is included for your reference. If you use bridge networking instead, you must uncomment and adjust these port mappings.
 :::
 
 ### 3. Deploy the Project
@@ -95,6 +106,20 @@ If the command returns no output, port 53 is no longer in use. After that, you s
 ### ⚠️ Disabling dnsmasq may affect other NAS-related DNS services. Make sure that AdGuard Home is configured correctly and starts automatically to take over its functionality.
 
 ## ⚙️ Initial Configuration of AdGuard Home
+
+After the container starts successfully, open the web interface again by visiting  `http://your-nas-name.local:3000` in your browser.
+
+You will be guided through a short setup wizard. In the wizard:
+
+- Set a username and password for the admin interface.
+- Configure which upstream DNS servers to use (e.g., 1.1.1.1 or 8.8.8.8).
+- Define the listening interfaces (usually 0.0.0.0 to listen on all).
+- Optionally enable DHCP services, if AdGuard Home should manage IPs on your network.
+- Review and apply your settings.
+
+Once complete, the dashboard will show DNS statistics and allow further customization like blacklists, rewrites, client rules, and logging.
+
+Make sure to set your router or clients to use your NAS IP as their DNS server so AdGuard Home becomes active in your network.
 
 After the container starts successfully, open the web interface again by visiting  `http://your-nas-name.local:3000` in your browser.
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -1,9 +1,9 @@
 # How to install AdGuard Home on Docker
 
-::: tip PREREQUISITE  
-AdGuard Home needs to bind to port 53 (DNS). On UGOS, this port is often already used by `dnsmasq` or other services.  
-Before installing, ensure that no other service is using port 53, or be prepared to disable/conflict-resolving as described below.
-:::
+> [!TIP] PREREQUISITE  
+>AdGuard Home needs to bind to port 53 (DNS). On UGOS, this port is often already used by `dnsmasq` or other services.  
+>Before installing, ensure that no other service is using port 53, or be prepared to disable/conflict-resolving as described below.
+
 
 AdGuard Home is a network-wide DNS server and blocker that filters ads, trackers, and malicious domains at the DNS level — before they even reach your devices. It acts as a local DNS resolver, allowing you to:
 
@@ -14,9 +14,9 @@ AdGuard Home is a network-wide DNS server and blocker that filters ads, trackers
 
 Unlike browser-based ad blockers, AdGuard Home works for all devices on your network — with no need to install anything on each one.
 
-::: warning  
-This guide was last tested for AdGuard Home v0.107.63
-:::  
+> [!WARNING]  
+>This guide was last tested for AdGuard Home v0.107.63
+
 
 ## Deploy Container Using Docker Compose
 

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -73,7 +73,7 @@ services:
 
 Once the deployment is complete, you can access the AdGuard Home web interface by visiting `http://your-nas-name.local:3000` in your browser.
 
-> [!WARNING]
+> [!CAUTION]
 > Preventing Port Conflicts with `dnsmasq`:
 >
 >By default, UGOS uses `dnsmasq` to handle DNS requests, which binds to port `53` on `localhost`. This will conflict with AdGuard >Home, which also needs to bind to port `53`.

--- a/docs/ugos/install/adguardhome/index.md
+++ b/docs/ugos/install/adguardhome/index.md
@@ -21,15 +21,17 @@ In the UGOS Pro system of UGREEN NAS, open the "Docker" app, click "Project > Cr
 
 In the wizard, you'll need to provide a Docker Compose configuration file. Below is the example configuration file for AdGuard Home:
 
-	services:
-	  adguardhome:
-		container_name: adguardhome
-		image: adguard/adguardhome:latest
-		restart: unless-stopped
-		network_mode: host
-		volumes:
-		  - /volume2/docker/adguardhome/work:/opt/adguardhome/work
-		  - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
+```yml
+services:
+  adguardhome:
+    container_name: adguardhome
+    image: adguard/adguardhome:latest
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - /volume2/docker/adguardhome/work:/opt/adguardhome/work
+      - /volume2/docker/adguardhome/conf:/opt/adguardhome/conf
+```
 
 ::: details
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Documentation/Content changes


## What is the current behavior?

There is currently no documentation available for installing AdGuard Home on Ugreen NAS devices using Docker.

## What is the new behavior?

- Adds a step-by-step guide for deploying AdGuard Home via Docker Compose on Ugreen OS  
- Explains Docker settings like `volumes`, `network_mode: host`, and container restart policy  
- Provides instructions for accessing the AdGuard Home web interface after deployment  
- Includes expandable "details" section to explain configuration choices  
- Mentions how to prevent port conflicts with existing services like `dnsmasq`

## Summary by Sourcery

Introduce AdGuard Home installation documentation for UGOS, updating the sidebar and providing a detailed Docker Compose guide with setup and conflict resolution

Documentation:
- Add step-by-step AdGuard Home installation guide using Docker Compose on Ugreen OS with instructions for volumes, network_mode, and restart policy
- Update UGOS documentation sidebar to include the new AdGuard Home installation page