### PR TITLE
Virt mgr passthrough folder

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -25,8 +25,8 @@ export default {
         {
           text: 'Getting Started',
           items: [
-            { 
-              text: 'Official Beginner\'s Guide', 
+            {
+              text: 'Official Beginner\'s Guide',
               link: 'https://nas.ugreen.com/pages/nasync-series-beginner-guide',
               target: '_blank' // This makes the link open in a new tab
             },
@@ -51,7 +51,7 @@ export default {
                 { text: 'Ngnix Proxy Manager', link: '/ugos/install/npm' },
                 { text: 'OpenWebUI', link: '/ugos/install/open-webui' },
                 { text: 'Tailscale', link: '/ugos/install/tailscale' },
-                { text: 'AdGuard Home', link: '/ugos/install/adguardhome'} 
+                { text: 'AdGuard Home', link: '/ugos/install/adguardhome'}
               ]
             },
             {
@@ -68,6 +68,7 @@ export default {
         items: [
           { text: 'Accessing BIOS', link: '/advanced-guides/accessing-bios' },
           { text: 'Backup UGOS SSD', link: '/advanced-guides/clonezilla-backup' },
+          { text: 'VM Folder Passthrough', link: '/advanced-guides/vm-folder-passthrough' },
           // ... other advanced guides
         ]
         },
@@ -102,4 +103,4 @@ export default {
       /^https?:\/\/raw.githubusercontent.com/,
     ],
   }
-  
+

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -26,8 +26,7 @@
     ```
 
     - NOTE: The Name will be in the format of a UUID, e.g. "f229f5ce-b904-4027-a50b-ba24b1d8e2ea"
-    - NOTE: Here is a guide on how to change the name of a VM to a more user-friendly name:
-      - https://ugreen.community/virtual-machine-name-change.md
+    - NOTE: If you followed the [virtual-machine-name-change guide](https://guide.ugreen.community/advanced-guides/virtual-machine-name-change.html), then the name should be easier to find.
 
 3. Dump the VM XML to a temp file:
 

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -26,7 +26,7 @@
     ```
 
     - NOTE: The Name will be in the format of a UUID, e.g. "f229f5ce-b904-4027-a50b-ba24b1d8e2ea"
-    - NOTE: If you followed the [virtual-machine-name-change guide](./virtual-machine-name-change.html), then the name should be easier to find.
+    - NOTE: If you followed the [virtual-machine-name-change guide](./vm-name-change.html), then the name should be easier to find.
 
 3. Dump the VM XML to a temp file:
 

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -62,16 +62,15 @@ Place it anywhere before `<devices>`, as long as it’s a sibling of `<memory>`,
     ```
 
     - Replace `/volume1/projects` with the host path you want to mount.
-    - The `<target dir='projects-fs'/>` string is the **tag** the VM will mount.
-  Remember this tag exactly (case‑sensitive).
+    - The `<target dir='projects-fs'/>` string is the **tag** the VM will mount. Remember this tag exactly (case‑sensitive).
 
-7. Redefine the VM from the modified XML:
+6. Redefine the VM from the modified XML:
 
     ```bash
     virsh define /tmp/vm-config.xml
     ```
 
-8. Restart the VM so the new config is applied:
+7. Restart the VM so the new config is applied:
 
     ```bash
     virsh shutdown <vm-name>
@@ -188,7 +187,5 @@ As your non-root user, create a file:
 
 ## 5. Common gotchas to double‑check
 
-- The tag in fstab (`projects-fs`) must exactly match the `<target dir='...'/>`
-  tag in the VM XML.
+- The tag in fstab (`projects-fs`) must exactly match the `<target dir='...'/>` tag in the VM XML.
 - If you ever edit the VM via the UGOS GUI, you may lose the `<filesystem>` block. If the mount suddenly fails, re‑add the XML block and restart the VM.
-

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -1,9 +1,12 @@
-# UGOS Pro: virtiofs host folder into VM with fstab automount
+# VirtioFS host folder into VM with fstab automount
 
-> Goal: Share a host folder from UGOS Pro into a Linux VM using virtiofs, and have it mounted via `/etc/fstab` without breaking boot.
-> We also use `bindfs` inside the VM so your VM user has correct read/write permissions, and files created inside the VM map correctly to UGOS's user and "admin" group (GID 10).
+::: info GOAL
+Share a host folder from UGOS Pro into a Linux VM using virtiofs, and have it mounted via `/etc/fstab` without breaking boot.
+We also use `bindfs` inside the VM so your VM user has correct read/write permissions, and files created inside the VM map correctly to UGOS's user and "admin" group (GID 10).
+:::
 
-***
+> [!WARNING]
+> This guide was written for UGOS Pro only, and was last tested with the version 1.13.x
 
 ## 1. On the UGOS host: add virtiofs to the VM
 
@@ -25,7 +28,8 @@
     virsh list --all
     ```
 
-    - NOTE: The Name will be in the format of a UUID, e.g. "f229f5ce-b904-4027-a50b-ba24b1d8e2ea"
+    > [!NOTE]
+    > The Name will be in the format of a UUID, e.g. "f229f5ce-b904-4027-a50b-ba24b1d8e2ea"
 
 3. Dump the VM XML to a temp file:
 
@@ -43,10 +47,12 @@
     </memoryBacking>
     ```
 
-Place it anywhere before `<devices>`, as long as it’s a sibling of `<memory>`, `<vcpu>`, `<devices>`, etc.
+    Place it anywhere before `<devices>`, as long as it’s a sibling of `<memory>`, `<vcpu>`, `<devices>`, etc.
 
 5. In the same XML file, inside the `<devices>` section, add a `filesystem` block:
-   - **NOTE**: modify the `/volume1/projects` path below to the full path of your shared folder. You can rename the 'tag' in the <target dir=...> field too; remember this tag for later.
+   
+    > [!NOTE]
+    > Modify the `/volume1/projects` path below to the full path of your shared folder. You can rename the 'tag' in the `<target dir=...>` field too; remember this tag for later.
 
     ```xml
     <devices>
@@ -76,8 +82,6 @@ Place it anywhere before `<devices>`, as long as it’s a sibling of `<memory>`,
     virsh start <vm-name>
     ```
 
-***
-
 ## 2. Inside the VM: Install bindfs and create mount points
 
 Because UGOS forces `passthrough` access mode for virtiofs, the mount will show up owned by `root:root` with strict permissions. We use `bindfs` to remap this safely for your normal user without modifying the host.
@@ -101,8 +105,6 @@ Because UGOS forces `passthrough` access mode for virtiofs, the mount will show 
     - `projects-fs` must exactly match the `<target dir='...'/>` tag in the VM XML.
     - If this works and `/mnt/projects` shows the host files, proceed to edit `/etc/fstab` for automount, otherwise fix the issue before continuing.
 
-***
-
 ## 3. Configure fstab with virtiofs and bindfs
 
 We will mount the raw virtiofs share to the hidden folder, then use `bindfs` to present it to the final folder with the correct user permissions.
@@ -116,8 +118,11 @@ We will mount the raw virtiofs share to the hidden folder, then use `bindfs` to 
 
 2. Add these two lines. (Assume your VM user's UID is `1000`, and UGOS expects files to be created with group "admin", which is GID `10`):
 
-    - **NOTE**: It works best if the USERNAME inside your VM matches the USERNAME in UGOS that you want to have ownership of the files created inside this folder.
-    - **NOTE**: If you don't know the UID of your VM user, run this command: `id $USER`. The admin GID of 10 is required by UGOS, please don't change that.
+    > [!NOTE]
+    > It works best if the USERNAME inside your VM matches the USERNAME in UGOS that you want to have ownership of the files created inside this folder.
+    
+    > [!NOTE]
+    > If you don't know the UID of your VM user, run this command: `id $USER`. The admin GID of 10 is required by UGOS, please don't change that.
 
     ```fstab
     # 1. Mount raw virtiofs to a hidden staging folder
@@ -138,8 +143,6 @@ We will mount the raw virtiofs share to the hidden folder, then use `bindfs` to 
     ```bash
     sudo systemctl daemon-reload
     ```
-
-***
 
 ## 4. Verify automount works
 
@@ -174,7 +177,8 @@ We will mount the raw virtiofs share to the hidden folder, then use `bindfs` to 
     - You should see a line showing `projects-fs` mounted on `/mnt/projects` with type `virtiofs`.
 
 4. Test file creation:
-As your non-root user, create a file:
+
+    As your non-root user, create a file:
 
     ```bash
     touch /mnt/projects/test-file.txt
@@ -182,9 +186,11 @@ As your non-root user, create a file:
 
     - If you check this file on the UGOS host via SSH (`ls -l /volume1/projects/test-file.txt`), it will correctly show as owned by your UGOS user and the `admin` group.
 
-***
-
 ## 5. Common gotchas to double‑check
 
 - The tag in fstab (`projects-fs`) must exactly match the `<target dir='...'/>` tag in the VM XML.
 - If you ever edit the VM via the UGOS GUI, you may lose the `<filesystem>` block. If the mount suddenly fails, re‑add the XML block and restart the VM.
+
+::: info Credit
+This guide was created by [Drauku](https://github.com/Drauku)
+:::

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -26,7 +26,7 @@
     ```
 
     - NOTE: The Name will be in the format of a UUID, e.g. "f229f5ce-b904-4027-a50b-ba24b1d8e2ea"
-    - NOTE: If you followed the [virtual-machine-name-change guide](https://guide.ugreen.community/advanced-guides/virtual-machine-name-change.html), then the name should be easier to find.
+    - NOTE: If you followed the [virtual-machine-name-change guide](./virtual-machine-name-change.html), then the name should be easier to find.
 
 3. Dump the VM XML to a temp file:
 
@@ -47,6 +47,7 @@
 Place it anywhere before `<devices>`, as long as it’s a sibling of `<memory>`, `<vcpu>`, `<devices>`, etc.
 
 5. In the same XML file, inside the `<devices>` section, add a `filesystem` block:
+   - **NOTE**: modify the `/volume1/projects` path below to the full path of your shared folder. You can rename the 'tag' in the <target dir=...> field too; remember this tag for later.
 
     ```xml
     <devices>
@@ -64,13 +65,13 @@ Place it anywhere before `<devices>`, as long as it’s a sibling of `<memory>`,
     - The `<target dir='projects-fs'/>` string is the **tag** the VM will mount.
   Remember this tag exactly (case‑sensitive).
 
-6. Redefine the VM from the modified XML:
+7. Redefine the VM from the modified XML:
 
     ```bash
     virsh define /tmp/vm-config.xml
     ```
 
-7. Restart the VM so the new config is applied:
+8. Restart the VM so the new config is applied:
 
     ```bash
     virsh shutdown <vm-name>
@@ -117,7 +118,8 @@ We will mount the raw virtiofs share to the hidden folder, then use `bindfs` to 
 
 2. Add these two lines. (Assume your VM user's UID is `1000`, and UGOS expects files to be created with group "admin", which is GID `10`):
 
-    - NOTE: It works best if the USERNAME inside your VM matches the USERNAME in UGOS that you want to have ownership of the files created inside this folder.
+    - **NOTE**: It works best if the USERNAME inside your VM matches the USERNAME in UGOS that you want to have ownership of the files created inside this folder.
+    - **NOTE**: If you don't know the UID of your VM user, run this command: `id $USER`. The admin GID of 10 is required by UGOS, please don't change that.
 
     ```fstab
     # 1. Mount raw virtiofs to a hidden staging folder

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -118,7 +118,7 @@ We will mount the raw virtiofs share to the hidden folder, then use `bindfs` to 
 
 2. Add these two lines. (Assume your VM user's UID is `1000`, and UGOS expects files to be created with group "admin", which is GID `10`):
 
-    - NOTE: It works best if the USERNAME inside your VM matches the USERNAME in UGOS that you want having ownership of the files created inside this folder.
+    - NOTE: It works best if the USERNAME inside your VM matches the USERNAME in UGOS that you want to have ownership of the files created inside this folder.
 
     ```fstab
     # 1. Mount raw virtiofs to a hidden staging folder

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -1,0 +1,193 @@
+# UGOS Pro: virtiofs host folder into VM with fstab automount
+
+> Goal: Share a host folder from UGOS Pro into a Linux VM using virtiofs, and have it mounted via `/etc/fstab` without breaking boot.
+> We also use `bindfs` inside the VM so your VM user has correct read/write permissions, and files created inside the VM map correctly to UGOS's user and "admin" group (GID 10).
+
+***
+
+## 1. On the UGOS host: add virtiofs to the VM
+
+1. SSH into the UGOS host and become root:
+
+    ```bash
+    ssh root@<ugos-host>
+    ```
+
+    - or ssh \<username>@\<ugos-host> then:
+
+    ```bash
+    sudo -i   # if sudo exists, otherwise use whatever UGOS provides for root
+    ```
+
+2. Find your VM name in libvirt:
+
+    ```bash
+    virsh list --all
+    ```
+
+    - NOTE: The Name will be in the format of a UUID, e.g. "f229f5ce-b904-4027-a50b-ba24b1d8e2ea"
+    - NOTE: Here is a guide on how to change the name of a VM to a more user-friendly name:
+      - https://ugreen.community/virtual-machine-name-change.md
+
+3. Dump the VM XML to a temp file:
+
+    ```bash
+    virsh dumpxml <vm-name> > /tmp/vm-config.xml
+    ```
+
+4. Edit `/tmp/vm-config.xml` and add **shared memory backing** at top level
+   (as a direct child of `<domain>`, not inside `<devices>`):
+
+    ```xml
+    <memoryBacking>
+        <access mode='shared'/>
+        <source type='memfd'/>
+    </memoryBacking>
+    ```
+
+Place it anywhere before `<devices>`, as long as it’s a sibling of `<memory>`, `<vcpu>`, `<devices>`, etc.
+
+5. In the same XML file, inside the `<devices>` section, add a `filesystem` block:
+
+    ```xml
+    <devices>
+        ...
+        <filesystem type='mount' accessmode='passthrough'>
+        <driver type='virtiofs'/>
+        <source dir='/volume1/projects'/>
+        <target dir='projects-fs'/>
+        </filesystem>
+        ...
+    </devices>
+    ```
+
+    - Replace `/volume1/projects` with the host path you want to mount.
+    - The `<target dir='projects-fs'/>` string is the **tag** the VM will mount.
+  Remember this tag exactly (case‑sensitive).
+
+6. Redefine the VM from the modified XML:
+
+    ```bash
+    virsh define /tmp/vm-config.xml
+    ```
+
+7. Restart the VM so the new config is applied:
+
+    ```bash
+    virsh shutdown <vm-name>
+    virsh start <vm-name>
+    ```
+
+***
+
+## 2. Inside the VM: Install bindfs and create mount points
+
+Because UGOS forces `passthrough` access mode for virtiofs, the mount will show up owned by `root:root` with strict permissions. We use `bindfs` to remap this safely for your normal user without modifying the host.
+
+1. Log into the VM (console or SSH).
+
+2. Install `bindfs` (Debian/Ubuntu example):
+
+    ```bash
+    sudo apt update
+    sudo apt install bindfs
+    ```
+
+3. Create two mount points (one raw/hidden, and one for your user):
+
+    ```bash
+    sudo mkdir -p /mnt/.projects-raw
+    sudo mkdir -p /mnt/projects
+    ```
+
+    - `projects-fs` must exactly match the `<target dir='...'/>` tag in the VM XML.
+    - If this works and `/mnt/projects` shows the host files, proceed to edit `/etc/fstab` for automount, otherwise fix the issue before continuing.
+
+***
+
+## 3. Configure fstab with virtiofs and bindfs
+
+We will mount the raw virtiofs share to the hidden folder, then use `bindfs` to present it to the final folder with the correct user permissions.
+
+
+1. Edit `/etc/fstab` in the **VM**:
+
+    ```bash
+    sudo nano /etc/fstab
+    ```
+
+2. Add these two lines. (Assume your VM user's UID is `1000`, and UGOS expects files to be created with group "admin", which is GID `10`):
+
+    - NOTE: It works best if the USERNAME inside your VM matches the USERNAME in UGOS that you want having ownership of the files created inside this folder.
+
+    ```fstab
+    # 1. Mount raw virtiofs to a hidden staging folder
+    projects-fs  /mnt/.projects-raw  virtiofs  nofail,x-systemd.automount,x-systemd.device-timeout=10  0  0
+
+    # 2. Use bindfs to remap ownership and permissions to your user
+    bindfs#/mnt/.projects-raw  /mnt/projects  fuse  force-user=1000,force-group=1000,create-as-user,create-for-group=10,chown-ignore,chgrp-ignore,perms=0770,nofail,x-systemd.requires=/mnt/.projects-raw  0  0
+    ```
+
+    **What these flags do:**
+    - `x-systemd.automount`: Defers mounting until first access so it doesn't break VM boot timing.
+    - `force-user=1000,force-group=1000,perms=0770`: Makes `/mnt/projects` completely readable/writable by your VM user (UID/GID 1000).
+    - `create-as-user,create-for-group=10`: Ensures files created by your VM user map correctly to your host user and the UGOS `admin` group (GID 10).
+    - `chown-ignore,chgrp-ignore`: Prevents permission errors when the VM OS attempts to change ownership on the FUSE mount.
+
+3. Reload systemd units so the new fstab is recognized:
+
+    ```bash
+    sudo systemctl daemon-reload
+    ```
+
+***
+
+## 4. Verify automount works
+
+1. Trigger the automount by accessing the raw folder, then mount the bindfs layer:
+
+    - *(Alternatively, just reboot the VM).*
+
+    ```bash
+    ls /mnt/.projects-raw
+    sudo mount /mnt/projects
+    ```
+
+2. Verify ownership:
+    ```bash
+    ls -ld /mnt/projects
+    ```
+
+    - It should now show `drwxrwx--- youruser yourgroup ... /mnt/projects`.
+
+3. Optional: confirm with `mount`:
+
+    ```bash
+    mount | grep projects-fs
+    ```
+
+    - or:
+
+    ```bash
+    mount | grep /mnt/projects
+    ```
+
+    - You should see a line showing `projects-fs` mounted on `/mnt/projects` with type `virtiofs`.
+
+4. Test file creation:
+As your non-root user, create a file:
+
+    ```bash
+    touch /mnt/projects/test-file.txt
+    ```
+
+    - If you check this file on the UGOS host via SSH (`ls -l /volume1/projects/test-file.txt`), it will correctly show as owned by your UGOS user and the `admin` group.
+
+***
+
+## 5. Common gotchas to double‑check
+
+- The tag in fstab (`projects-fs`) must exactly match the `<target dir='...'/>`
+  tag in the VM XML.
+- If you ever edit the VM via the UGOS GUI, you may lose the `<filesystem>` block. If the mount suddenly fails, re‑add the XML block and restart the VM.
+

--- a/docs/advanced-guides/vm-folder-passthrough.md
+++ b/docs/advanced-guides/vm-folder-passthrough.md
@@ -26,7 +26,6 @@
     ```
 
     - NOTE: The Name will be in the format of a UUID, e.g. "f229f5ce-b904-4027-a50b-ba24b1d8e2ea"
-    - NOTE: If you followed the [virtual-machine-name-change guide](./vm-name-change.html), then the name should be easier to find.
 
 3. Dump the VM XML to a temp file:
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [x] Documentation/Content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Add a guide for passing through any host folder on the NASync device into a virtual machine created using the UGOS Virt Manager App.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Summary by Sourcery

Add documentation for configuring virtiofs-based host folder passthrough into UGOS virtual machines with safe automounting inside the guest.

Enhancements:
- Expose the new VM folder passthrough guide in the advanced guides navigation menu.

Documentation:
- Add an advanced guide describing how to share a UGOS host folder into a Linux VM using virtiofs, bindfs, and fstab-based automount configuration.